### PR TITLE
2.0.0 |  Fix transitions by adding `isOpen` prop to popup props + deprecate access to internal logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,31 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
-## [1.0.0] - 2020-05-11
-### Changed
-- ``
+## [1.2.0] - 2020-05-13
+### Fixed
+- Animations on show and hide were fixed! <br>
+  There was an issue with the current approach to show and hide popups.<br>
+  It added and removed dom elements, preventing the in-code transition solution
+  of external popup-libraries.<br>
+  <i>for example: instead of fade out, it just disappeared</i>
+  > there is a threshold of only 10 closed popups. so shouldn't hurt performance
+### Added
+to get the upgrade features that fix the animation issue you need to use these:
+- `withIsOpen` - new `Prop` for `PopupProvider` - <br>
+  this changes approach from deleting popup from DOM to changing its `show`/`isOpen` state<br>
+
+  >:warning:&nbsp;**Important** - &nbsp;only use with new `isOpen` prop below
+
+- `isOpen` - new `Prop` added to existing `PopupProps`. <br>
+  The `props` that are added to consumers popup by calling `popupManager.open()` function.<br>
+
+  >:warning:&nbsp;**Important** - &nbsp;only use with new `withIsOpen` prop above
+
 ### Deprecated
-- `PopupManager.openPopups` is replaced with `PopupManager.popups`
+- `PopupManager.openPopups`  - for internal use only. will be removed in the future.
+- `PopupManager.onPopupsChangeEvents`  - for internal use  only. will be removed in the future.
+- `PopupManager.subscribeOnPopupsChange`  - for internal use  only. will be removed in the future.
+- `PopupManager.close`  - for internal use  only. will be removed in the future.
+
+
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
-## [1.2.0] - 2020-05-13
+## [2.0.0] - 2020-05-14
 ### Fixed
 - Animations on show and hide were fixed! <br>
   There was an issue with the current approach to show and hide popups.<br>
@@ -11,19 +11,14 @@ All notable changes to this project will be documented in this file.
   > there is a threshold of only 10 closed popups. so shouldn't hurt performance
 ### Added
 to get the upgrade features that fix the animation issue you need to use these:
-- `withIsOpen` - new `Prop` for `PopupProvider` - <br>
-  this changes approach from deleting popup from DOM to changing its `show`/`isOpen` state<br>
-
-  >:warning:&nbsp;**Important** - &nbsp;only use with new `isOpen` prop below
-
 - `isOpen` - new `Prop` added to existing `PopupProps`. <br>
-  The `props` that are added to consumers popup by calling `popupManager.open()` function.<br>
+  The `props` that are added to consumers popup when calling `popupManager.open()` function.<br>
 
-  >:warning:&nbsp;**Important** - &nbsp;only use with new `withIsOpen` prop above
+  >:warning:&nbsp;**Important** - &nbsp; must use in consumers popup otherwise it will never close
 
 ### Deprecated
 - `popupProps.isOpen` in `PopupManager.open(component, popupProps)`  - is not allowed. is saved for internal use.
-  >:warning:&nbsp;**Important** - &nbsp; will throw exception if adding `withIsOpen` to `PopupProvider`
+  >:warning:&nbsp;**Important** - &nbsp; will throw exception if added
 - `PopupManager.openPopups`  - for internal use only and will be removed in the future.
 - `PopupManager.onPopupsChangeEvents`  - for internal use  only and will be removed in the future.
 - `PopupManager.subscribeOnPopupsChange`  - for internal use  only and will be removed in the future.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 - Transitions on show and hide were fixed! <br>
   There was an issue with the current approach to show and hide popups.<br>
-  It added and removed dom elements, preventing the in-code transition solution of external popup-libraries.
-  <i>for example: instead of fade out, it use to just disappear</i>
+  It added and removed dom elements, preventing the in-code transition solution of external popup-libraries.<br>
+  ><i>for example: instead of fade out, it use to just disappear</i>
 ### Changed
 - Changed `PopupManager` `close` approach:<br>
   Instead of adding and removing it from the DOM, it changes popup's `isOpen` prop.<br>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,14 @@ All notable changes to this project will be documented in this file.
 
 ## [2.0.0] - 2020-05-14
 ### Fixed
-- Animations on show and hide were fixed! <br>
-  There was an issue with the current approach to show and hide popups.<br>
-  It added and removed dom elements, preventing the in-code transition solution
-  of external popup-libraries.<br>
-  <i>for example: instead of fade out, it just disappeared</i>
+- Transitions on show and hide were fixed! <br>
+  There was an issue with the current approach to show and hide popups.<br>  
+  It added and removed dom elements, preventing the in-code transition solution of external popup-libraries.
+  <i>for example: instead of fade out, it use to just disappear</i>
+### Changed
+- Changed `PopupManager` `close` approach:<br>
+  Instead of adding and removing it from the DOM, it changes popup's `isOpen` prop.<br>
+  This will allow in-library implemented transitions on `Open` and on `Close`.<br>
   > there is a threshold of only 10 closed popups. so shouldn't hurt performance
 ### Added
 to get the upgrade features that fix the animation issue you need to use these:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,10 +22,12 @@ to get the upgrade features that fix the animation issue you need to use these:
   >:warning:&nbsp;**Important** - &nbsp;only use with new `withIsOpen` prop above
 
 ### Deprecated
-- `PopupManager.openPopups`  - for internal use only. will be removed in the future.
-- `PopupManager.onPopupsChangeEvents`  - for internal use  only. will be removed in the future.
-- `PopupManager.subscribeOnPopupsChange`  - for internal use  only. will be removed in the future.
-- `PopupManager.close`  - for internal use  only. will be removed in the future.
+- `popupProps.isOpen` in `PopupManager.open(component, popupProps)`  - is not allowed. is saved for internal use.
+  >:warning:&nbsp;**Important** - &nbsp; will throw exception if adding `withIsOpen` to `PopupProvider`
+- `PopupManager.openPopups`  - for internal use only and will be removed in the future.
+- `PopupManager.onPopupsChangeEvents`  - for internal use  only and will be removed in the future.
+- `PopupManager.subscribeOnPopupsChange`  - for internal use  only and will be removed in the future.
+- `PopupManager.close`  - for internal use  only and will be removed in the future.
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 ## [2.0.0] - 2020-05-14
 ### Fixed
 - Transitions on show and hide were fixed! <br>
-  There was an issue with the current approach to show and hide popups.<br>  
+  There was an issue with the current approach to show and hide popups.<br>
   It added and removed dom elements, preventing the in-code transition solution of external popup-libraries.
   <i>for example: instead of fade out, it use to just disappear</i>
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+## [1.0.0] - 2020-05-11
+### Changed
+- ``
+### Deprecated
+- `PopupManager.openPopups` is replaced with `PopupManager.popups`

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ The library is agnostic to any popup library you decide to use.
 `props`:
 * `popupManager` <i>(optional)</i> - Popup Manager. can send custom extended `PopupManager`. <br>
  <i>~ Default : uses `PopupManager`</i>
- * `withIsOpen` <i>(optional)</i> - **Fixes** open and close transitions of popups.<br>
+ * `withIsOpen` <i>(optional but **Recommended**)</i> - **Fixes** open and close transitions of popups.<br>
    Adds managing of `IsOpen` for opened popup. <br>
    <i>~ Default : `false`</i>
 
@@ -107,6 +107,7 @@ HOC that adds `popupManager` to `props` of component
 * `componentClass` - component's class or function
 * `popupProps` <i>(optional)</i> - popup's props.
     * `onClose` - will be called on actual popup close with arguments
+     > `isOpen` shouldn't be used!
 * returns - object of open popup
     * `close` - closes the popup
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ import { PopupProvider } from "react-popup-manager";
 import { Main } from "./Main";
 
 ReactDOM.render(
-  <PopupProvider>
+  <PopupProvider withIsOpen={true}>
     <Main />
   </PopupProvider>,
   document.getElementById("root")
@@ -67,8 +67,10 @@ export class MyModal extends React.Component {
     }
 
     render() {
+        const { isOpen } = this.props;
+
         return (
-            <Modal isOpen={true} >
+            <Modal isOpen={isOpen} >
                <span>{this.props.title}</span>
                <button onClick={() => this.close()}> close </button>
              </Modal>
@@ -88,6 +90,9 @@ The library is agnostic to any popup library you decide to use.
 `props`:
 * `popupManager` <i>(optional)</i> - Popup Manager. can send custom extended `PopupManager`. <br>
  <i>~ Default : uses `PopupManager`</i>
+ * `withIsOpen` <i>(optional)</i> - **Fixes** open and close transitions of popups.<br>
+   Adds managing of `IsOpen` for opened popup. <br>
+   <i>~ Default : `false`</i>
 
 ### `withPopups(managerName)`
 HOC that adds `popupManager` to `props` of component

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ HOC that adds `popupManager` to `props` of component
 ### `PopupManager`
 `open(componentClass, popupProps)` - opens popup. render's popup component
 * `componentClass` - component's class or function
-* `popupProps` <i>(optional)</i> - consumers popup props and accept these props:
+* `popupProps` <i>(optional)</i> - consumers popup props and also accepts these:
     * `onClose` - will be called on actual popup close with arguments
      > `isOpen` is not allowed.
 * returns - object of instance of open popup

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ import { PopupProvider } from "react-popup-manager";
 import { Main } from "./Main";
 
 ReactDOM.render(
-  <PopupProvider withIsOpen={true}>
+  <PopupProvider>
     <Main />
   </PopupProvider>,
   document.getElementById("root")
@@ -90,9 +90,6 @@ The library is agnostic to any popup library you decide to use.
 `props`:
 * `popupManager` <i>(optional)</i> - Popup Manager. can send custom extended `PopupManager`. <br>
  <i>~ Default : uses `PopupManager`</i>
- * `withIsOpen` <i>(optional but **Recommended**)</i> - **Fixes** open and close transitions of popups.<br>
-   Adds managing of `IsOpen` for opened popup. <br>
-   <i>~ Default : `false`</i>
 
 ### `withPopups(managerName)`
 HOC that adds `popupManager` to `props` of component
@@ -105,10 +102,10 @@ HOC that adds `popupManager` to `props` of component
 ### `PopupManager`
 `open(componentClass, popupProps)` - opens popup. render's popup component
 * `componentClass` - component's class or function
-* `popupProps` <i>(optional)</i> - popup's props.
+* `popupProps` <i>(optional)</i> - consumers popup props and accept these props:
     * `onClose` - will be called on actual popup close with arguments
-     > `isOpen` shouldn't be used!
-* returns - object of open popup
+     > `isOpen` is not allowed.
+* returns - object of instance of open popup
     * `close` - closes the popup
 
 `closeAll()` - closes all open popups. removes popup from DOM

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "homepage": "https://github.com/wix-incubator/react-popup-manager#readme",
   "bugs": {
-      "url": "https://github.com/wix-incubator/react-popup-manager/issues"
+    "url": "https://github.com/wix-incubator/react-popup-manager/issues"
   },
   "keywords": [
     "react",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-popup-manager",
-  "version": "1.2.0",
+  "version": "2.0.0",
   "description": "Manage react popups, Modals, Lightboxes, Notifications, etc. easily",
   "license": "MIT",
   "private": false,
@@ -55,7 +55,7 @@
     "react": "^16.8.3",
     "react-dom": "^16.8.3",
     "react-test-renderer": "^16.8.3",
-    "typescript": "~3.0.1",
+    "typescript": "~3.5.0",
     "yoshi": "^3.0.0"
   },
   "lint-staged": {

--- a/package.json
+++ b/package.json
@@ -43,20 +43,20 @@
     "notification"
   ],
   "devDependencies": {
+    "@types/enzyme": "^3.9.0",
+    "@types/jest": "~23.3.1",
+    "@types/react": "^16.8.5",
+    "@types/react-dom": "^16.8.2",
     "enzyme": "^3.9.0",
     "enzyme-adapter-react-16": "^1.11.2",
     "jest-yoshi-preset": "^3.5.0",
     "lint-staged": "^7.2.2",
+    "puppeteer": "^1.1.0",
     "react": "^16.8.3",
     "react-dom": "^16.8.3",
     "react-test-renderer": "^16.8.3",
-    "yoshi": "^3.0.0",
     "typescript": "~3.0.1",
-    "puppeteer": "^1.1.0",
-    "@types/jest": "~23.3.1",
-    "@types/react": "^16.8.5",
-    "@types/react-dom": "^16.8.2",
-    "@types/enzyme": "^3.9.0"
+    "yoshi": "^3.0.0"
   },
   "lint-staged": {
     "linters": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-popup-manager",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Manage react popups, Modals, Lightboxes, Notifications, etc. easily",
   "license": "MIT",
   "private": false,

--- a/src/PopupProvider.tsx
+++ b/src/PopupProvider.tsx
@@ -5,6 +5,7 @@ import { PopupContext } from './PopupContext';
 
 export interface PopupsProviderProps {
   popupManager?: PopupManager;
+  withIsOpen?: boolean;
   children?: any;
 }
 
@@ -12,7 +13,8 @@ export class PopupProvider extends React.Component<PopupsProviderProps> {
   private readonly popupManager: PopupManager;
   constructor(props, context) {
     super(props, context);
-    this.popupManager = props.popupManager || new PopupManager();
+    this.popupManager =
+      props.popupManager || new PopupManager({ withIsOpen: props.withIsOpen });
   }
 
   public render() {

--- a/src/PopupProvider.tsx
+++ b/src/PopupProvider.tsx
@@ -2,7 +2,8 @@ import * as React from 'react';
 
 import { PopupsWrapper } from './PopupsWrapper';
 import { PopupContext } from './PopupContext';
-import {PopupManager} from './popupManager';
+import { PopupManager } from './popupManager';
+import { PopupManagerInternal } from './__internal__/popupManagerInternal';
 
 export interface PopupsProviderProps {
   popupManager?: PopupManager;
@@ -11,11 +12,11 @@ export interface PopupsProviderProps {
 }
 
 export class PopupProvider extends React.Component<PopupsProviderProps> {
-  private readonly popupManager: PopupManager;
+  private readonly popupManager: PopupManagerInternal;
   constructor(props, context) {
     super(props, context);
     this.popupManager = props.popupManager || new PopupManager();
-    props.popupManager.withIsOpen = props.withIsOpen;
+    this.popupManager.withIsOpen = props.withIsOpen;
   }
 
   public render() {

--- a/src/PopupProvider.tsx
+++ b/src/PopupProvider.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
-import { PopupManager } from './popupManager';
+
 import { PopupsWrapper } from './PopupsWrapper';
 import { PopupContext } from './PopupContext';
+import {PopupManager} from './popupManager';
 
 export interface PopupsProviderProps {
   popupManager?: PopupManager;
@@ -13,9 +14,8 @@ export class PopupProvider extends React.Component<PopupsProviderProps> {
   private readonly popupManager: PopupManager;
   constructor(props, context) {
     super(props, context);
-    this.popupManager =
-      props.popupManager || new PopupManager();
-      props.popupManager.withIsOpen = props.withIsOpen;
+    this.popupManager = props.popupManager || new PopupManager();
+    props.popupManager.withIsOpen = props.withIsOpen;
   }
 
   public render() {

--- a/src/PopupProvider.tsx
+++ b/src/PopupProvider.tsx
@@ -7,7 +7,6 @@ import { PopupManagerInternal } from './__internal__/popupManagerInternal';
 
 export interface PopupsProviderProps {
   popupManager?: PopupManager;
-  withIsOpen?: boolean;
   children?: any;
 }
 
@@ -16,7 +15,6 @@ export class PopupProvider extends React.Component<PopupsProviderProps> {
   constructor(props, context) {
     super(props, context);
     this.popupManager = props.popupManager || new PopupManager();
-    this.popupManager.withIsOpen = props.withIsOpen;
   }
 
   public render() {

--- a/src/PopupProvider.tsx
+++ b/src/PopupProvider.tsx
@@ -14,7 +14,8 @@ export class PopupProvider extends React.Component<PopupsProviderProps> {
   constructor(props, context) {
     super(props, context);
     this.popupManager =
-      props.popupManager || new PopupManager({ withIsOpen: props.withIsOpen });
+      props.popupManager || new PopupManager();
+      props.popupManager.withIsOpen = props.withIsOpen;
   }
 
   public render() {

--- a/src/PopupsWrapper.tsx
+++ b/src/PopupsWrapper.tsx
@@ -15,7 +15,7 @@ class SinglePopupLifeCycle extends React.Component<SinglePopupLifeCycleProps> {
   state = { isOpen: false };
 
   componentDidMount(): void {
-    if (this.props.isOpen === false) {
+    if (this.props.isOpen === true) {
       this.setState({ isOpen: true });
     }
   }

--- a/src/PopupsWrapper.tsx
+++ b/src/PopupsWrapper.tsx
@@ -7,7 +7,7 @@ export interface PopupsWrapperProps {
 
 interface SinglePopupLifeCycleProps {
   currentPopup: PopupItem;
-  onClose(currentPopup: PopupItem, ...params): any;
+  onClose(params: any[]): any;
   isOpen: boolean;
 }
 
@@ -21,7 +21,7 @@ class SinglePopupLifeCycle extends React.Component<SinglePopupLifeCycleProps> {
   }
 
   componentWillReceiveProps(
-    nextProps: Readonly<SinglePopupLifeCycleProps>,
+    nextProps: Readonly <SinglePopupLifeCycleProps>,
     nextContext: any,
   ): void {
     if (nextProps.isOpen === false) {
@@ -36,7 +36,7 @@ class SinglePopupLifeCycle extends React.Component<SinglePopupLifeCycleProps> {
       <currentPopup.ComponentClass
         {...currentPopup.props}
         isOpen={this.state.isOpen}
-        onClose={(...params) => onClose(currentPopup, params)}
+        onClose={(...params) => onClose(params)}
       />
     );
   }
@@ -63,7 +63,7 @@ export class PopupsWrapper extends React.Component<PopupsWrapperProps> {
         currentPopup={currentPopup}
         key={currentPopup.guid}
         isOpen={true}
-        onClose={(...params) => this.onClose(currentPopup, params)}
+        onClose={(params) => this.onClose(currentPopup, params)}
       />
     ));
   }

--- a/src/PopupsWrapper.tsx
+++ b/src/PopupsWrapper.tsx
@@ -48,11 +48,11 @@ class SinglePopupLifeCycle extends React.Component<SinglePopupLifeCycleProps> {
 export class PopupsWrapper extends React.Component<PopupsWrapperProps> {
   constructor(props) {
     super(props);
-    props.popupManager.subscribeOnPopupsChange(() => this.forceUpdate());
+    props.popupManager._subscribeOnPopupsChange(() => this.forceUpdate());
   }
 
   private onClose(currentPopup: PopupItem, params) {
-    this.props.popupManager.close(currentPopup.guid);
+    this.props.popupManager._close(currentPopup.guid);
     currentPopup.props &&
       currentPopup.props.onClose &&
       currentPopup.props.onClose(...params);

--- a/src/PopupsWrapper.tsx
+++ b/src/PopupsWrapper.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react';
-import { PopupItem, PopupManager } from './popupManager';
+import { PopupItem } from './__internal__/PopupItem';
+import { PopupManagerInternal } from './__internal__/popupManagerInternal';
 
-export interface PopupsWrapperProps {
-  popupManager: PopupManager;
+interface PopupsWrapperProps {
+  popupManager: PopupManagerInternal;
 }
 
 interface SinglePopupLifeCycleProps {
@@ -20,13 +21,15 @@ class SinglePopupLifeCycle extends React.Component<SinglePopupLifeCycleProps> {
     }
   }
 
-  componentWillReceiveProps(
+  static getDerivedStateFromProps(
     nextProps: Readonly<SinglePopupLifeCycleProps>,
-    nextContext: any,
-  ): void {
+    prevState: any,
+  ): any {
     if (nextProps.isOpen === false) {
-      this.setState({ isOpen: false });
+      return { isOpen: false };
     }
+
+    return null;
   }
 
   render() {

--- a/src/PopupsWrapper.tsx
+++ b/src/PopupsWrapper.tsx
@@ -48,11 +48,11 @@ class SinglePopupLifeCycle extends React.Component<SinglePopupLifeCycleProps> {
 export class PopupsWrapper extends React.Component<PopupsWrapperProps> {
   constructor(props) {
     super(props);
-    props.popupManager._subscribeOnPopupsChange(() => this.forceUpdate());
+    props.popupManager.subscribeOnPopupsChange(() => this.forceUpdate());
   }
 
   private onClose(currentPopup: PopupItem, params) {
-    this.props.popupManager._close(currentPopup.guid);
+    this.props.popupManager.close(currentPopup.guid);
     currentPopup.props &&
       currentPopup.props.onClose &&
       currentPopup.props.onClose(...params);

--- a/src/PopupsWrapper.tsx
+++ b/src/PopupsWrapper.tsx
@@ -5,6 +5,43 @@ export interface PopupsWrapperProps {
   popupManager: PopupManager;
 }
 
+interface SinglePopupLifeCycleProps {
+  currentPopup: PopupItem;
+  onClose(currentPopup: PopupItem, ...params): any;
+  isOpen: boolean;
+}
+
+class SinglePopupLifeCycle extends React.Component<SinglePopupLifeCycleProps> {
+  state = { isOpen: false };
+
+  componentDidMount(): void {
+    if (this.props.isOpen === false) {
+      this.setState({ isOpen: true });
+    }
+  }
+
+  componentWillReceiveProps(
+    nextProps: Readonly<SinglePopupLifeCycleProps>,
+    nextContext: any,
+  ): void {
+    if (nextProps.isOpen === false) {
+      this.setState({ isOpen: false });
+    }
+  }
+
+  render() {
+    const { currentPopup, onClose } = this.props;
+
+    return (
+      <currentPopup.ComponentClass
+        {...currentPopup.props}
+        isOpen={this.state.isOpen}
+        onClose={(...params) => onClose(currentPopup, params)}
+      />
+    );
+  }
+}
+
 export class PopupsWrapper extends React.Component<PopupsWrapperProps> {
   constructor(props) {
     super(props);
@@ -22,9 +59,10 @@ export class PopupsWrapper extends React.Component<PopupsWrapperProps> {
     const { popupManager } = this.props;
 
     return popupManager.openPopups.map(currentPopup => (
-      <currentPopup.ComponentClass
-        {...currentPopup.props}
+      <SinglePopupLifeCycle
+        currentPopup={currentPopup}
         key={currentPopup.guid}
+        isOpen={true}
         onClose={(...params) => this.onClose(currentPopup, params)}
       />
     ));

--- a/src/PopupsWrapper.tsx
+++ b/src/PopupsWrapper.tsx
@@ -21,7 +21,7 @@ class SinglePopupLifeCycle extends React.Component<SinglePopupLifeCycleProps> {
   }
 
   componentWillReceiveProps(
-    nextProps: Readonly <SinglePopupLifeCycleProps>,
+    nextProps: Readonly<SinglePopupLifeCycleProps>,
     nextContext: any,
   ): void {
     if (nextProps.isOpen === false) {
@@ -34,8 +34,8 @@ class SinglePopupLifeCycle extends React.Component<SinglePopupLifeCycleProps> {
 
     return (
       <currentPopup.ComponentClass
-        {...currentPopup.props}
         isOpen={this.state.isOpen}
+        {...currentPopup.props}
         onClose={(...params) => onClose(params)}
       />
     );
@@ -58,12 +58,12 @@ export class PopupsWrapper extends React.Component<PopupsWrapperProps> {
   public render() {
     const { popupManager } = this.props;
 
-    return popupManager.openPopups.map(currentPopup => (
+    return popupManager.popups.map(currentPopup => (
       <SinglePopupLifeCycle
         currentPopup={currentPopup}
         key={currentPopup.guid}
-        isOpen={true}
-        onClose={(params) => this.onClose(currentPopup, params)}
+        isOpen={currentPopup.isOpen}
+        onClose={params => this.onClose(currentPopup, params)}
       />
     ));
   }

--- a/src/__internal__/PopupItem.ts
+++ b/src/__internal__/PopupItem.ts
@@ -1,9 +1,5 @@
 import { PopupAcceptedProps } from '../popupsDef';
 
-export interface popupInstance {
-  close: Function;
-}
-
 type PopupItemProps = PopupAcceptedProps & { [key: string]: any };
 
 export class PopupItem {

--- a/src/__internal__/PopupItem.ts
+++ b/src/__internal__/PopupItem.ts
@@ -1,6 +1,6 @@
-import { PopupAcceptedProps } from '../popupsDef';
+import { PopupProps } from '../popupsDef';
 
-type PopupItemProps = PopupAcceptedProps & { [key: string]: any };
+type PopupItemProps = PopupProps & { [key: string]: any };
 
 export class PopupItem {
   private _isOpen: boolean;

--- a/src/__internal__/PopupItem.ts
+++ b/src/__internal__/PopupItem.ts
@@ -1,0 +1,27 @@
+import { PopupAcceptedProps } from '../popupsDef';
+
+export interface popupInstance {
+  close: Function;
+}
+
+type PopupItemProps = PopupAcceptedProps & { [key: string]: any };
+
+export class PopupItem {
+  private _isOpen: boolean;
+
+  constructor(
+    public ComponentClass: any,
+    public props: PopupItemProps,
+    public guid: string,
+  ) {
+    this._isOpen = true;
+  }
+
+  public get isOpen() {
+    return this._isOpen;
+  }
+
+  public close() {
+    this._isOpen = false;
+  }
+}

--- a/src/__internal__/common.ts
+++ b/src/__internal__/common.ts
@@ -1,0 +1,5 @@
+export const deprecatedWarningMessage = functionName =>
+  `'${functionName}' is deprecated. this is for internal use only and will be removed in future versions`;
+
+export const deprecatedPropWarningMessage = propName =>
+  `'${propName}' prop is deprecated and will be not be allowed in future versions`;

--- a/src/__internal__/common.ts
+++ b/src/__internal__/common.ts
@@ -1,5 +1,0 @@
-export const deprecatedWarningMessage = functionName =>
-  `'${functionName}' is deprecated. this is for internal use only and will be removed in future versions`;
-
-export const deprecatedPropWarningMessage = propName =>
-  `'${propName}' prop is deprecated and will be not be allowed in future versions`;

--- a/src/__internal__/popupManagerInternal.ts
+++ b/src/__internal__/popupManagerInternal.ts
@@ -1,6 +1,6 @@
 import { generateGuid } from '../utils/generateGuid';
-import { PopupAcceptedProps } from '../popupsDef';
-import { popupInstance, PopupItem } from './PopupItem';
+import { PopupAcceptedProps, popupInstance } from '../popupsDef';
+import { PopupItem } from './PopupItem';
 
 const CLOSED_POPUPS_THRESHOLD = 10;
 
@@ -8,8 +8,8 @@ export type OpenPopupOptions<T> = T & PopupAcceptedProps;
 
 export class PopupManagerInternal {
   private _openPopups: PopupItem[] = [];
-  private _closedPopups: PopupItem[] = [];
-  private readonly withIsOpen: boolean = false;
+  private readonly _closedPopups: PopupItem[] = [];
+  public withIsOpen: boolean = false;
   protected _onPopupsChangeEvents: Function[] = [];
 
   public get onPopupsChangeEvents() {
@@ -73,7 +73,10 @@ export class PopupManagerInternal {
   }
 
   public closeAll(): void {
-    this._closedPopups = [...this._openPopups.reverse(), ...this._closedPopups];
+    this._openPopups.forEach(popup => {
+      popup.close();
+      this._closedPopups.unshift(popup);
+    });
     this._openPopups = [];
     this.callPopupsChangeEvents();
   }

--- a/src/__internal__/popupManagerInternal.ts
+++ b/src/__internal__/popupManagerInternal.ts
@@ -1,21 +1,13 @@
 import { generateGuid } from '../utils/generateGuid';
 import { popupInstance, PopupProps } from '../popupsDef';
 import { PopupItem } from './PopupItem';
+import { PopupManager } from '../popupManager';
 
 const CLOSED_POPUPS_THRESHOLD = 10;
 
 export type OpenPopupOptions<T> = Omit<T & PopupProps, 'isOpen'>;
 
-export interface IPopupManager {
-  open<T>(
-    componentClass: React.ComponentType<T>,
-    popupProps?: OpenPopupOptions<T>,
-  ): popupInstance;
-
-  closeAll(): void;
-}
-
-export class PopupManagerInternal implements IPopupManager {
+export class PopupManagerInternal implements PopupManager {
   private openPopups: PopupItem[] = [];
   private readonly _closedPopups: PopupItem[] = [];
   public onPopupsChangeEvents: Function[] = [];

--- a/src/__internal__/popupManagerInternal.ts
+++ b/src/__internal__/popupManagerInternal.ts
@@ -6,9 +6,6 @@ const CLOSED_POPUPS_THRESHOLD = 10;
 
 export type OpenPopupOptions<T> = T & PopupAcceptedProps;
 
-export const deprecatedWarningMessage = functionName =>
-  `'${functionName}' is deprecated. this is for internal use only and will be removed in future versions`;
-
 export class PopupManagerInternal {
   private _openPopups: PopupItem[] = [];
   private readonly _closedPopups: PopupItem[] = [];
@@ -43,6 +40,12 @@ export class PopupManagerInternal {
     componentClass: React.ComponentType<T>,
     popupProps?: OpenPopupOptions<T>,
   ): popupInstance {
+    if ((popupProps as any).isOpen && this.withIsOpen) {
+      throw new Error(
+        `'isOpen' prop is deprecated and not allowed. if you wish to use it, remove 'withIsOpen' from 'PopupProvider'`,
+      );
+    }
+
     const guid = generateGuid();
     const newPopupItem = new PopupItem(componentClass, popupProps as any, guid);
     this._openPopups.push(newPopupItem);

--- a/src/__internal__/popupManagerInternal.ts
+++ b/src/__internal__/popupManagerInternal.ts
@@ -1,0 +1,80 @@
+import { generateGuid } from '../utils/generateGuid';
+import { PopupAcceptedProps } from '../popupsDef';
+import { popupInstance, PopupItem } from './PopupItem';
+
+const CLOSED_POPUPS_THRESHOLD = 10;
+
+export type OpenPopupOptions<T> = T & PopupAcceptedProps;
+
+export class PopupManagerInternal {
+  private _openPopups: PopupItem[] = [];
+  private _closedPopups: PopupItem[] = [];
+  private readonly withIsOpen: boolean = false;
+  protected _onPopupsChangeEvents: Function[] = [];
+
+  public get onPopupsChangeEvents() {
+    return this._onPopupsChangeEvents;
+  }
+
+  private callPopupsChangeEvents() {
+    this.onPopupsChangeEvents.forEach(cb => cb());
+  }
+
+  private get closedPopups() {
+    this._closedPopups.length = Math.min(
+      this._closedPopups.length,
+      CLOSED_POPUPS_THRESHOLD,
+    );
+    return this._closedPopups;
+  }
+
+  public subscribeOnPopupsChange(callback: Function): void {
+    this.onPopupsChangeEvents.push(callback);
+  }
+
+  public get popups() {
+    if (this.withIsOpen) {
+      return [...this._openPopups, ...this.closedPopups];
+    }
+
+    return this._openPopups;
+  }
+
+  public open<T>(
+    componentClass: React.ComponentType<T>,
+    popupProps?: OpenPopupOptions<T>,
+  ): popupInstance {
+    const guid = generateGuid();
+    const newPopupItem = new PopupItem(componentClass, popupProps as any, guid);
+    this._openPopups.push(newPopupItem);
+
+    this.callPopupsChangeEvents();
+    return {
+      close: () => this.close(guid),
+    };
+  }
+
+  public close(popupGuid: string): void {
+    const currentPopupIndex = this._openPopups.findIndex(
+      ({ guid }) => guid === popupGuid,
+    );
+
+    if (currentPopupIndex === -1) {
+      return;
+    }
+
+    const currentPopup = this._openPopups[currentPopupIndex];
+
+    currentPopup.close();
+
+    const closedPopup = this._openPopups.splice(currentPopupIndex, 1)[0];
+    this._closedPopups.unshift(closedPopup);
+    this.callPopupsChangeEvents();
+  }
+
+  public closeAll(): void {
+    this._closedPopups = [...this._openPopups.reverse(), ...this._closedPopups];
+    this._openPopups = [];
+    this.callPopupsChangeEvents();
+  }
+}

--- a/src/__internal__/popupManagerInternal.ts
+++ b/src/__internal__/popupManagerInternal.ts
@@ -6,18 +6,17 @@ const CLOSED_POPUPS_THRESHOLD = 10;
 
 export type OpenPopupOptions<T> = T & PopupAcceptedProps;
 
+export const deprecatedWarningMessage = functionName =>
+  `'${functionName}' is deprecated. this is for internal use only and will be removed in future versions`;
+
 export class PopupManagerInternal {
   private _openPopups: PopupItem[] = [];
   private readonly _closedPopups: PopupItem[] = [];
   public withIsOpen: boolean = false;
-  protected _onPopupsChangeEvents: Function[] = [];
-
-  public get onPopupsChangeEvents() {
-    return this._onPopupsChangeEvents;
-  }
+  public _onPopupsChangeEvents: Function[] = [];
 
   private callPopupsChangeEvents() {
-    this.onPopupsChangeEvents.forEach(cb => cb());
+    this._onPopupsChangeEvents.forEach(cb => cb());
   }
 
   private get closedPopups() {
@@ -28,8 +27,8 @@ export class PopupManagerInternal {
     return this._closedPopups;
   }
 
-  public subscribeOnPopupsChange(callback: Function): void {
-    this.onPopupsChangeEvents.push(callback);
+  public _subscribeOnPopupsChange(callback: Function): void {
+    this._onPopupsChangeEvents.push(callback);
   }
 
   public get popups() {
@@ -50,11 +49,11 @@ export class PopupManagerInternal {
 
     this.callPopupsChangeEvents();
     return {
-      close: () => this.close(guid),
+      close: () => this._close(guid),
     };
   }
 
-  public close(popupGuid: string): void {
+  public _close(popupGuid: string): void {
     const currentPopupIndex = this._openPopups.findIndex(
       ({ guid }) => guid === popupGuid,
     );

--- a/src/popupManager.ts
+++ b/src/popupManager.ts
@@ -1,10 +1,10 @@
 import * as React from 'react';
 import { generateGuid } from './utils/generateGuid';
-import { PopupProps } from './popupsDef';
+import { PopupAcceptedProps } from './popupsDef';
 
 export interface PopupItem {
   ComponentClass: any;
-  props: PopupProps & { [key: string]: any };
+  props: PopupAcceptedProps & { [key: string]: any };
   guid: string;
 }
 
@@ -12,18 +12,7 @@ export interface popupInstance {
   close: Function;
 }
 
-type Omit<T, K> = Pick<T & PopupProps, Exclude<keyof (T & PopupProps), K>>;
-
-type OpenPopupOptionsOld<T> = T & PopupProps;
-type OpenPopupOptions<T> = Omit<T & PopupProps, 'isOpen'>;
-
-// type OpenPopupOptionsOld<T> = {
-//   onClose?(...params): any;
-//   isOpen?: boolean;
-// };
-// type OpenPopupOptions<T> = {
-//   onClose?(...params): any;
-// };
+type OpenPopupOptions<T> =  T & PopupAcceptedProps;
 
 export class PopupManager {
   public openPopups: PopupItem[] = [];
@@ -36,17 +25,6 @@ export class PopupManager {
   public subscribeOnPopupsChange(callback: Function): void {
     this.onPopupsChangeEvents.push(callback);
   }
-
-  public open<T>(
-    componentClass: React.ComponentType<T>,
-    popupProps?: OpenPopupOptions<T>,
-  ): popupInstance;
-
-  /** @deprecated should not set isOpen ever  */
-  public open<T>(
-    componentClass: React.ComponentType<T>,
-    popupProps?: OpenPopupOptionsOld<T>,
-  ): popupInstance;
 
   public open<T>(
     componentClass: React.ComponentType<T>,

--- a/src/popupManager.ts
+++ b/src/popupManager.ts
@@ -3,9 +3,11 @@ import {
   OpenPopupOptions,
   PopupManagerInternal,
 } from './__internal__/popupManagerInternal';
-import { popupInstance, PopupItem } from './__internal__/PopupItem';
+import { PopupItem } from './__internal__/PopupItem';
+import { popupInstance } from './popupsDef';
 
 interface IPopupManagerDeprecated {
+
   open<T>(
     componentClass: React.ComponentType<T>,
     popupProps?: OpenPopupOptions<T>,
@@ -47,7 +49,5 @@ class PopupManagerDeprecated extends PopupManagerInternal
 
 type Constructable<T> = new (...args: []) => T;
 
-type IPopupManager = Constructable<IPopupManagerDeprecated>;
-
-export const PopupManager: IPopupManager = PopupManagerDeprecated as any;
-
+export type PopupManager = IPopupManagerDeprecated;
+export const PopupManager: Constructable<PopupManager> = PopupManagerDeprecated as any;

--- a/src/popupManager.ts
+++ b/src/popupManager.ts
@@ -1,11 +1,14 @@
 import * as React from 'react';
 import {
-  deprecatedWarningMessage,
   OpenPopupOptions,
   PopupManagerInternal,
 } from './__internal__/popupManagerInternal';
 import { PopupItem } from './__internal__/PopupItem';
 import { popupInstance } from './popupsDef';
+import {
+  deprecatedPropWarningMessage,
+  deprecatedWarningMessage,
+} from './__internal__/common';
 
 interface IPopupManagerDeprecated {
   open<T>(
@@ -32,8 +35,22 @@ function deprecated(functionName) {
   console.warn(deprecatedWarningMessage(functionName));
 }
 
+function deprecatedProp(propName) {
+  console.warn(deprecatedPropWarningMessage(propName));
+}
+
 class PopupManagerDeprecated extends PopupManagerInternal
   implements IPopupManagerDeprecated {
+  public open<T>(
+    componentClass: React.ComponentType<T>,
+    popupProps?: OpenPopupOptions<T>,
+  ): popupInstance {
+    if ((popupProps as any).isOpen) {
+      deprecatedProp('isOpen');
+    }
+    return super.open(componentClass, popupProps);
+  }
+
   public get openPopups() {
     deprecated('openPopups');
     return this.popups;

--- a/src/popupManager.ts
+++ b/src/popupManager.ts
@@ -1,9 +1,17 @@
 import {
   PopupManagerInternal,
-  IPopupManager,
+  OpenPopupOptions,
 } from './__internal__/popupManagerInternal';
+import { popupInstance } from './popupsDef';
 
 type Constructable<T> = new (...args: []) => T;
 
-export type PopupManager = IPopupManager;
-export const PopupManager: Constructable<IPopupManager> = PopupManagerInternal as any;
+export interface PopupManager {
+  open<T>(
+    componentClass: React.ComponentType<T>,
+    popupProps?: OpenPopupOptions<T>,
+  ): popupInstance;
+
+  closeAll(): void;
+}
+export const PopupManager: Constructable<PopupManager> = PopupManagerInternal as any;

--- a/src/popupManager.ts
+++ b/src/popupManager.ts
@@ -1,78 +1,9 @@
-import * as React from 'react';
 import {
-  OpenPopupOptions,
   PopupManagerInternal,
+  IPopupManager,
 } from './__internal__/popupManagerInternal';
-import { PopupItem } from './__internal__/PopupItem';
-import { popupInstance } from './popupsDef';
-import {
-  deprecatedPropWarningMessage,
-  deprecatedWarningMessage,
-} from './__internal__/common';
-
-interface IPopupManagerDeprecated {
-  open<T>(
-    componentClass: React.ComponentType<T>,
-    popupProps?: OpenPopupOptions<T>,
-  ): popupInstance;
-
-  closeAll(): void;
-
-  /* @deprecated: this is for internal usage only*/
-  openPopups: PopupItem[];
-
-  /* @deprecated: this is for internal usage only*/
-  onPopupsChangeEvents: Function[];
-
-  /* @deprecated: this is for internal usage only*/
-  close(guid: string);
-
-  /* @deprecated: this is for internal usage only*/
-  subscribeOnPopupsChange(callback: Function): void;
-}
-
-function deprecated(functionName) {
-  console.warn(deprecatedWarningMessage(functionName));
-}
-
-function deprecatedProp(propName) {
-  console.warn(deprecatedPropWarningMessage(propName));
-}
-
-class PopupManagerDeprecated extends PopupManagerInternal
-  implements IPopupManagerDeprecated {
-  public open<T>(
-    componentClass: React.ComponentType<T>,
-    popupProps?: OpenPopupOptions<T>,
-  ): popupInstance {
-    if ((popupProps as any).isOpen) {
-      deprecatedProp('isOpen');
-    }
-    return super.open(componentClass, popupProps);
-  }
-
-  public get openPopups() {
-    deprecated('openPopups');
-    return this.popups;
-  }
-
-  public get onPopupsChangeEvents(): Function[] {
-    deprecated('onPopupsChangeEvents');
-    return this._onPopupsChangeEvents;
-  }
-
-  public close(guid: string) {
-    deprecated('close');
-    return super._close(guid);
-  }
-
-  public subscribeOnPopupsChange(callback: Function): void {
-    deprecated('subscribeOnPopupsChange');
-    return super._subscribeOnPopupsChange(callback);
-  }
-}
 
 type Constructable<T> = new (...args: []) => T;
 
-export type PopupManager = IPopupManagerDeprecated;
-export const PopupManager: Constructable<PopupManager> = PopupManagerDeprecated as any;
+export type PopupManager = IPopupManager;
+export const PopupManager: Constructable<IPopupManager> = PopupManagerInternal as any;

--- a/src/popupManager.ts
+++ b/src/popupManager.ts
@@ -20,7 +20,7 @@ export class PopupItem {
     public props: PopupItemProps,
     public guid: string,
   ) {
-    this._isOpen = false;
+    this._isOpen = true;
   }
 
   public get isOpen() {
@@ -32,15 +32,11 @@ export class PopupItem {
   }
 }
 
-export class PopupManager {
+export class PopupManagerInternal {
   private _openPopups: PopupItem[] = [];
   private _closedPopups: PopupItem[] = [];
   private readonly withIsOpen: boolean = false;
   public onPopupsChangeEvents: Function[] = [];
-
-  constructor(options: { withIsOpen?: boolean } = {}) {
-    this.withIsOpen = options.withIsOpen;
-  }
 
   private callPopupsChangeEvents() {
     this.onPopupsChangeEvents.forEach(cb => cb());
@@ -107,3 +103,20 @@ export class PopupManager {
     this.callPopupsChangeEvents();
   }
 }
+
+
+type Omit<T, K> = Pick<T, Exclude<keyof T, K>>;
+
+// fake type - just an idea
+type Deprecated<T> = {
+  /* @deprecated: is for internal usage only */
+  [P in keyof T]: T[P];
+};
+
+type IPopupManager = Pick<PopupManagerInternal, "open" | "closeAll"> & Deprecated<Omit<PopupManagerInternal, "open" | "closeAll">> ;
+
+const PopupManager: IPopupManager  = <any>PopupManagerInternal;
+
+const d = new PopupManager();
+d.withIsOpen;
+d.close('');

--- a/src/popupManager.ts
+++ b/src/popupManager.ts
@@ -4,13 +4,26 @@ import { PopupProps } from './popupsDef';
 
 export interface PopupItem {
   ComponentClass: any;
-  props: any;
+  props: PopupProps & { [key: string]: any };
   guid: string;
 }
 
 export interface popupInstance {
   close: Function;
 }
+
+type Omit<T, K> = Pick<T & PopupProps, Exclude<keyof (T & PopupProps), K>>;
+
+type OpenPopupOptionsOld<T> = T & PopupProps;
+type OpenPopupOptions<T> = Omit<T & PopupProps, 'isOpen'>;
+
+// type OpenPopupOptionsOld<T> = {
+//   onClose?(...params): any;
+//   isOpen?: boolean;
+// };
+// type OpenPopupOptions<T> = {
+//   onClose?(...params): any;
+// };
 
 export class PopupManager {
   public openPopups: PopupItem[] = [];
@@ -26,12 +39,23 @@ export class PopupManager {
 
   public open<T>(
     componentClass: React.ComponentType<T>,
-    popupProps?: T & PopupProps,
+    popupProps?: OpenPopupOptions<T>,
+  ): popupInstance;
+
+  /** @deprecated should not set isOpen ever  */
+  public open<T>(
+    componentClass: React.ComponentType<T>,
+    popupProps?: OpenPopupOptionsOld<T>,
+  ): popupInstance;
+
+  public open<T>(
+    componentClass: React.ComponentType<T>,
+    popupProps?: OpenPopupOptions<T>,
   ): popupInstance {
     const guid = generateGuid();
     this.openPopups.push({
       ComponentClass: componentClass,
-      props: popupProps,
+      props: popupProps as any,
       guid,
     });
 

--- a/src/popupManager.ts
+++ b/src/popupManager.ts
@@ -1,122 +1,53 @@
 import * as React from 'react';
-import { generateGuid } from './utils/generateGuid';
-import { PopupAcceptedProps } from './popupsDef';
+import {
+  OpenPopupOptions,
+  PopupManagerInternal,
+} from './__internal__/popupManagerInternal';
+import { popupInstance, PopupItem } from './__internal__/PopupItem';
 
-export interface popupInstance {
-  close: Function;
+interface IPopupManagerDeprecated {
+  open<T>(
+    componentClass: React.ComponentType<T>,
+    popupProps?: OpenPopupOptions<T>,
+  ): popupInstance;
+
+  closeAll(): void;
+
+  /* @deprecated: this is for internal usage only*/
+  openPopups: PopupItem[];
+
+  /* @deprecated: this is for internal usage only*/
+  onPopupsChangeEvents: Function[];
+
+  /* @deprecated: this is for internal usage only*/
+  close(guid: string);
+
+  /* @deprecated: this is for internal usage only*/
+  subscribeOnPopupsChange(callback: Function): void;
 }
 
-type OpenPopupOptions<T> = T & PopupAcceptedProps;
-
-type PopupItemProps = PopupAcceptedProps & { [key: string]: any };
-
-const CLOSED_POPUPS_THRESHOLD = 10;
-
-export class PopupItem {
-  private _isOpen: boolean;
-
-  constructor(
-    public ComponentClass: any,
-    public props: PopupItemProps,
-    public guid: string,
-  ) {
-    this._isOpen = true;
+class PopupManagerDeprecated extends PopupManagerInternal
+  implements IPopupManagerDeprecated {
+  public get openPopups() {
+    return this.popups;
   }
 
-  public get isOpen() {
-    return this._isOpen;
+  public get onPopupsChangeEvents(): Function[] {
+    return this._onPopupsChangeEvents;
   }
 
-  public close() {
-    this._isOpen = false;
-  }
-}
-
-export class PopupManagerInternal {
-  private _openPopups: PopupItem[] = [];
-  private _closedPopups: PopupItem[] = [];
-  private readonly withIsOpen: boolean = false;
-  public onPopupsChangeEvents: Function[] = [];
-
-  private callPopupsChangeEvents() {
-    this.onPopupsChangeEvents.forEach(cb => cb());
-  }
-
-  private get closedPopups() {
-    this._closedPopups.length = Math.min(
-      this._closedPopups.length,
-      CLOSED_POPUPS_THRESHOLD,
-    );
-    return this._closedPopups;
+  public close(guid: string) {
+    return super.close(guid);
   }
 
   public subscribeOnPopupsChange(callback: Function): void {
-    this.onPopupsChangeEvents.push(callback);
-  }
-
-  /* @deprecated: use popups instead*/
-  public openPopups = this.popups;
-
-  public get popups() {
-    if (this.withIsOpen) {
-      return [...this._openPopups, ...this.closedPopups];
-    }
-
-    return this._openPopups;
-  }
-
-  public open<T>(
-    componentClass: React.ComponentType<T>,
-    popupProps?: OpenPopupOptions<T>,
-  ): popupInstance {
-    const guid = generateGuid();
-    const newPopupItem = new PopupItem(componentClass, popupProps as any, guid);
-    this._openPopups.push(newPopupItem);
-
-    this.callPopupsChangeEvents();
-    return {
-      close: () => this.close(guid),
-    };
-  }
-
-  public close(popupGuid: string): void {
-    const currentPopupIndex = this._openPopups.findIndex(
-      ({ guid }) => guid === popupGuid,
-    );
-
-    if (currentPopupIndex === -1) {
-      return;
-    }
-
-    const currentPopup = this._openPopups[currentPopupIndex];
-
-    currentPopup.close();
-
-    const closedPopup = this._openPopups.splice(currentPopupIndex, 1)[0];
-    this._closedPopups.unshift(closedPopup);
-    this.callPopupsChangeEvents();
-  }
-
-  public closeAll(): void {
-    this._closedPopups = [...this._openPopups.reverse(), ...this._closedPopups];
-    this._openPopups = [];
-    this.callPopupsChangeEvents();
+    return super.subscribeOnPopupsChange(callback);
   }
 }
 
+type Constructable<T> = new (...args: []) => T;
 
-type Omit<T, K> = Pick<T, Exclude<keyof T, K>>;
+type IPopupManager = Constructable<IPopupManagerDeprecated>;
 
-// fake type - just an idea
-type Deprecated<T> = {
-  /* @deprecated: is for internal usage only */
-  [P in keyof T]: T[P];
-};
+export const PopupManager: IPopupManager = PopupManagerDeprecated as any;
 
-type IPopupManager = Pick<PopupManagerInternal, "open" | "closeAll"> & Deprecated<Omit<PopupManagerInternal, "open" | "closeAll">> ;
-
-const PopupManager: IPopupManager  = <any>PopupManagerInternal;
-
-const d = new PopupManager();
-d.withIsOpen;
-d.close('');

--- a/src/popupManager.ts
+++ b/src/popupManager.ts
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import {
+  deprecatedWarningMessage,
   OpenPopupOptions,
   PopupManagerInternal,
 } from './__internal__/popupManagerInternal';
@@ -7,7 +8,6 @@ import { PopupItem } from './__internal__/PopupItem';
 import { popupInstance } from './popupsDef';
 
 interface IPopupManagerDeprecated {
-
   open<T>(
     componentClass: React.ComponentType<T>,
     popupProps?: OpenPopupOptions<T>,
@@ -28,22 +28,30 @@ interface IPopupManagerDeprecated {
   subscribeOnPopupsChange(callback: Function): void;
 }
 
+function deprecated(functionName) {
+  console.warn(deprecatedWarningMessage(functionName));
+}
+
 class PopupManagerDeprecated extends PopupManagerInternal
   implements IPopupManagerDeprecated {
   public get openPopups() {
+    deprecated('openPopups');
     return this.popups;
   }
 
   public get onPopupsChangeEvents(): Function[] {
+    deprecated('onPopupsChangeEvents');
     return this._onPopupsChangeEvents;
   }
 
   public close(guid: string) {
-    return super.close(guid);
+    deprecated('close');
+    return super._close(guid);
   }
 
   public subscribeOnPopupsChange(callback: Function): void {
-    return super.subscribeOnPopupsChange(callback);
+    deprecated('subscribeOnPopupsChange');
+    return super._subscribeOnPopupsChange(callback);
   }
 }
 

--- a/src/popupsDef.ts
+++ b/src/popupsDef.ts
@@ -1,5 +1,9 @@
 import { PopupManager } from './popupManager';
 
+export interface popupInstance {
+  close: Function;
+}
+
 export interface PopupAcceptedProps {
   onClose?(...params): any;
 }

--- a/src/popupsDef.ts
+++ b/src/popupsDef.ts
@@ -2,6 +2,7 @@ import { PopupManager } from './popupManager';
 
 export interface PopupProps {
   onClose?(...params): any;
+  isOpen?: boolean;
 }
 
 export interface WithPopupsProps {

--- a/src/popupsDef.ts
+++ b/src/popupsDef.ts
@@ -5,7 +5,7 @@ export interface popupInstance {
 }
 
 export interface PopupProps {
-  onClose?(...params): any;
+  onClose?: (...args: any[]) => any;
   isOpen?: boolean;
 }
 

--- a/src/popupsDef.ts
+++ b/src/popupsDef.ts
@@ -4,11 +4,7 @@ export interface popupInstance {
   close: Function;
 }
 
-export interface PopupAcceptedProps {
-  onClose?(...params): any;
-}
-
-export interface PopupProps extends PopupAcceptedProps {
+export interface PopupProps {
   onClose?(...params): any;
   isOpen?: boolean;
 }

--- a/src/popupsDef.ts
+++ b/src/popupsDef.ts
@@ -1,6 +1,10 @@
 import { PopupManager } from './popupManager';
 
-export interface PopupProps {
+export interface PopupAcceptedProps {
+  onClose?(...params): any;
+}
+
+export interface PopupProps extends PopupAcceptedProps{
   onClose?(...params): any;
   isOpen?: boolean;
 }

--- a/src/popupsDef.ts
+++ b/src/popupsDef.ts
@@ -4,7 +4,7 @@ export interface PopupAcceptedProps {
   onClose?(...params): any;
 }
 
-export interface PopupProps extends PopupAcceptedProps{
+export interface PopupProps extends PopupAcceptedProps {
   onClose?(...params): any;
   isOpen?: boolean;
 }

--- a/src/tests/TestPopups.driver.tsx
+++ b/src/tests/TestPopups.driver.tsx
@@ -33,7 +33,6 @@ export class PopupDriver {
 export class TestPopupsDriver {
   private componentType: React.ComponentType;
   private popupManager: PopupManager;
-  private withIsOpen: boolean;
   private popupManagerName: string;
   private component: ReactWrapper<any>;
   private readonly props = {};
@@ -59,10 +58,6 @@ export class TestPopupsDriver {
   }
 
   public given = {
-    withIsOpen: (withIsOpen: boolean): TestPopupsDriver  => {
-      this.withIsOpen = withIsOpen;
-      return this;
-    },
     popupManager: (popupManager: PopupManager, customName?: string): TestPopupsDriver => {
       this.popupManager = popupManager;
       this.popupManagerName = customName;
@@ -85,7 +80,6 @@ export class TestPopupsDriver {
         return (
           <PopupProvider
             {...(this.popupManager ? {popupManager: this.popupManager} : null)}
-            {...(this.withIsOpen ? {withIsOpen: true} : null)}
           >
             <ComponentWithPopupManager {...props} />
           </PopupProvider>

--- a/src/tests/TestPopups.driver.tsx
+++ b/src/tests/TestPopups.driver.tsx
@@ -1,8 +1,34 @@
 import * as React from 'react';
-import { configure, mount, ReactWrapper } from 'enzyme';
-import { withPopups, PopupManager, PopupProvider } from '..';
-import { PopupsDriver } from '../Popups.driver';
+import {configure, mount, ReactWrapper} from 'enzyme';
+import {withPopups, PopupManager, PopupProvider} from '..';
+import {PopupsDriver} from '../Popups.driver';
 import * as Adapter from 'enzyme-adapter-react-16';
+
+
+export class PopupDriver {
+  constructor(private component: ReactWrapper<any>) {
+  }
+
+  private getByDataHook(
+    hook: string,
+    parent: ReactWrapper<any, any> = this.component,
+  ): ReactWrapper<any, any> {
+    return parent.find(`[data-hook="${hook}"]`);
+  }
+
+  public when = {
+    closePopup: (): PopupDriver => {
+      this.get.closeButton().simulate('click');
+      return this;
+    },
+  };
+
+  public get = {
+    exists: () => this.component.exists(),
+    closeButton: () => this.getByDataHook('close-button'),
+    content: () => this.getByDataHook('popup-content').text(),
+  }
+}
 
 export class TestPopupsDriver {
   private componentType: React.ComponentType;
@@ -15,16 +41,16 @@ export class TestPopupsDriver {
     return new PopupsDriver(this.component);
   }
 
-  private render(Component: React.ComponentType<any>): ReactWrapper<any> {
-    configure({ adapter: new Adapter() });
-    return mount(<Component {...this.props} />);
-  }
-
   private getByDataHook(
     hook: string,
     parent: ReactWrapper<any, any> = this.component,
   ): ReactWrapper<any, any> {
     return parent.find(`[data-hook="${hook}"]`);
+  }
+
+  private render(Component: React.ComponentType<any>): ReactWrapper<any> {
+    configure({adapter: new Adapter()});
+    return mount(<Component {...this.props} />);
   }
 
   public update() {
@@ -51,40 +77,13 @@ export class TestPopupsDriver {
         );
 
         return (
-          <PopupProvider {...(this.popupManager ? {popupManager:this.popupManager}: null)}>
+          <PopupProvider {...(this.popupManager ? {popupManager: this.popupManager} : null)}>
             <ComponentWithPopupManager {...props} />
           </PopupProvider>
         );
       });
 
       return this;
-    },
-    testPopup1: {
-      closePopup: (): TestPopupsDriver => {
-        this.get
-          .testPopup1()
-          .closeButton()
-          .simulate('click');
-        return this;
-      },
-    },
-    testPopup2: {
-      closePopup: (): TestPopupsDriver => {
-        this.get
-          .testPopup2()
-          .closeButton()
-          .simulate('click');
-        return this;
-      },
-    },
-    testPopupWithAnimation: {
-      closePopup: (): TestPopupsDriver => {
-        this.get
-          .testPopupWithAnimation()
-          .closeButton()
-          .simulate('click');
-        return this;
-      },
     },
     inGivenComponent: {
       clickOn: (dataHook): TestPopupsDriver => {
@@ -98,46 +97,7 @@ export class TestPopupsDriver {
 
   public get = {
     givenComponent: () => this.component.find(this.componentType),
-    testPopupWithAnimation: () => ({
-      component: () => this.getByDataHook('test-popup-with-animation'),
-      exists: () =>
-        this.get
-          .testPopupWithAnimation()
-          .component()
-          .exists(),
-      closeButton: () =>
-        this.getByDataHook('close-button', this.get.testPopupWithAnimation().component()),
-      content: () =>
-        this.getByDataHook(
-          'popup-content',
-          this.get.testPopupWithAnimation().component(),
-        ).text(),
-    }),
-    testPopup1: () => ({
-      component: () => this.getByDataHook('test-hook'),
-      exists: () =>
-        this.get
-          .testPopup1()
-          .component()
-          .exists(),
-      closeButton: () =>
-        this.getByDataHook('close-button', this.get.testPopup1().component()),
-      content: () =>
-        this.getByDataHook(
-          'popup-content',
-          this.get.testPopup1().component(),
-        ).text(),
-    }),
-    testPopup2: () => ({
-      component: () => this.getByDataHook('test-hook2'),
-      exists: () =>
-        this.get
-          .testPopup2()
-          .component()
-          .exists(),
-      closeButton: () =>
-        this.getByDataHook('close-button', this.get.testPopup2().component()),
-    }),
+    popupDriver: (popupDataHook: string) => new PopupDriver(this.getByDataHook(popupDataHook)),
     isPopupOpen: () => this.getPopupsDriver().get.isAnyPopupsOpen(),
-  };
+  }
 }

--- a/src/tests/TestPopups.driver.tsx
+++ b/src/tests/TestPopups.driver.tsx
@@ -25,6 +25,7 @@ export class PopupDriver {
 
   public get = {
     exists: () => this.component.exists(),
+    isOpen: () => this.component.props()['is-open'],
     closeButton: () => this.getByDataHook('close-button'),
     content: () => this.getByDataHook('popup-content').text(),
   }
@@ -33,6 +34,7 @@ export class PopupDriver {
 export class TestPopupsDriver {
   private componentType: React.ComponentType;
   private popupManager: PopupManager;
+  private withIsOpen: boolean;
   private popupManagerName: string;
   private component: ReactWrapper<any>;
   private readonly props = {};
@@ -58,6 +60,10 @@ export class TestPopupsDriver {
   }
 
   public given = {
+    withIsOpen: (withIsOpen: boolean): TestPopupsDriver  => {
+      this.withIsOpen = withIsOpen;
+      return this;
+    },
     popupManager: (popupManager: PopupManager, customName?: string): TestPopupsDriver => {
       this.popupManager = popupManager;
       this.popupManagerName = customName;
@@ -77,7 +83,10 @@ export class TestPopupsDriver {
         );
 
         return (
-          <PopupProvider {...(this.popupManager ? {popupManager: this.popupManager} : null)}>
+          <PopupProvider
+            {...(this.popupManager ? {popupManager: this.popupManager} : null)}
+            {...(this.withIsOpen ? {withIsOpen: true} : null)}
+          >
             <ComponentWithPopupManager {...props} />
           </PopupProvider>
         );

--- a/src/tests/TestPopups.driver.tsx
+++ b/src/tests/TestPopups.driver.tsx
@@ -37,7 +37,7 @@ export class TestPopupsDriver {
       this.popupManagerName = customName;
       return this;
     },
-    component: (component: React.ComponentType): TestPopupsDriver => {
+    component: (component: React.ComponentType<any>): TestPopupsDriver => {
       this.componentType = component;
       return this;
     },
@@ -77,6 +77,15 @@ export class TestPopupsDriver {
         return this;
       },
     },
+    testPopupWithAnimation: {
+      closePopup: (): TestPopupsDriver => {
+        this.get
+          .testPopupWithAnimation()
+          .closeButton()
+          .simulate('click');
+        return this;
+      },
+    },
     inGivenComponent: {
       clickOn: (dataHook): TestPopupsDriver => {
         this.getByDataHook(dataHook, this.get.givenComponent()).simulate(
@@ -89,6 +98,21 @@ export class TestPopupsDriver {
 
   public get = {
     givenComponent: () => this.component.find(this.componentType),
+    testPopupWithAnimation: () => ({
+      component: () => this.getByDataHook('test-popup-with-animation'),
+      exists: () =>
+        this.get
+          .testPopupWithAnimation()
+          .component()
+          .exists(),
+      closeButton: () =>
+        this.getByDataHook('close-button', this.get.testPopupWithAnimation().component()),
+      content: () =>
+        this.getByDataHook(
+          'popup-content',
+          this.get.testPopupWithAnimation().component(),
+        ).text(),
+    }),
     testPopup1: () => ({
       component: () => this.getByDataHook('test-hook'),
       exists: () =>

--- a/src/tests/TestPopups.driver.tsx
+++ b/src/tests/TestPopups.driver.tsx
@@ -4,7 +4,6 @@ import {withPopups, PopupManager, PopupProvider} from '..';
 import {PopupsDriver} from '../Popups.driver';
 import * as Adapter from 'enzyme-adapter-react-16';
 
-
 export class PopupDriver {
   constructor(private component: ReactWrapper<any>) {
   }
@@ -77,6 +76,7 @@ export class TestPopupsDriver {
 
   public when = {
     create: (): TestPopupsDriver => {
+      this.componentType = this.componentType ? this.componentType : () => <div></div>;
       this.component = this.render(props => {
         const ComponentWithPopupManager = withPopups(this.popupManagerName)(
           _props1 => <this.componentType {..._props1} />,

--- a/src/tests/TestPopups.driver.tsx
+++ b/src/tests/TestPopups.driver.tsx
@@ -25,7 +25,7 @@ export class PopupDriver {
 
   public get = {
     exists: () => this.component.exists(),
-    isOpen: () => this.component.props()['is-open'],
+    isOpen: () => this.component.props()['data-is-open'],
     closeButton: () => this.getByDataHook('close-button'),
     content: () => this.getByDataHook('popup-content').text(),
   }

--- a/src/tests/testPopups.spec.tsx
+++ b/src/tests/testPopups.spec.tsx
@@ -1,7 +1,8 @@
 import { TestPopupsDriver } from './TestPopups.driver';
 import { TestPopupsManager } from './testPopupsManager';
 import * as React from 'react';
-import {TestPopup1} from "./testPopups";
+import {TestPopup1, TestPopupWithAnimation} from "./testPopups";
+import {PopupManager} from '../popupManager';
 
 describe('Popups', () => {
   let driver: TestPopupsDriver;
@@ -221,5 +222,32 @@ describe('Popups', () => {
     driver.when.inGivenComponent.clickOn('button-close-all');
     expect(driver.get.testPopup1().exists()).toBe(false);
     expect(driver.get.testPopup2().exists()).toBe(false);
+  });
+
+  fit('should close popup using isOpen - allow animation', () => {
+    const testedComponent = (props:{popupManager: PopupManager})  => (
+      <div>
+        <button
+          data-hook="button-open"
+          onClick={() => props.popupManager.open(TestPopupWithAnimation, {
+            onClose: () => console.log('popup was closed'),
+            timeOutMS: 100,
+            isOpen: true,
+          })}
+        />
+      </div>
+    );
+
+    driver.given.component(testedComponent);
+
+    driver.when.create();
+
+    expect(driver.get.isPopupOpen()).toBe(false);
+    driver.when.inGivenComponent.clickOn(buttonOpen);
+    driver.when.testPopupWithAnimation.closePopup();
+
+    expect(driver.get.testPopupWithAnimation().exists()).toBe(true);
+    jest.advanceTimersByTime(100);
+    expect(driver.get.testPopupWithAnimation().exists()).toBe(false);
   });
 });

--- a/src/tests/testPopups.spec.tsx
+++ b/src/tests/testPopups.spec.tsx
@@ -376,11 +376,8 @@ describe('Popups', () => {
 
       // all shouldn't be strikethrough
       aPopupManager._close('guid');
-
-      // reading getters
-      const [] = aPopupManager._onPopupsChangeEvents;
-      const [] = aPopupManager.popups;
-      // aPopupManager.openPopups only exists in deprecated backwards compatibility
+      aPopupManager._onPopupsChangeEvents;
+      aPopupManager.popups;
       aPopupManager._subscribeOnPopupsChange(() => ({}));
 
       expect(console.warn).not.toBeCalled();

--- a/src/tests/testPopups.spec.tsx
+++ b/src/tests/testPopups.spec.tsx
@@ -12,7 +12,7 @@ describe('Popups', () => {
 
   beforeEach(() => {
     driver = new TestPopupsDriver();
-    popupManager = new TestPopupsManager();
+    popupManager = new TestPopupsManager('string');
   });
 
   it('should open popup using default popup manager', () => {
@@ -296,7 +296,7 @@ describe('Popups', () => {
     });
 
     it('should close all popups. threshold 10. First Closed First Removed', () => {
-      const aPopupManager = new PopupManager({withIsOpen: true});
+      const aPopupManager = new PopupManager();
       const popupThreshold = 10;
       let popupDataHookIndex = 0;
       const testedComponent = (props: { popupManager: PopupManager }) => (
@@ -309,6 +309,7 @@ describe('Popups', () => {
       );
 
       driver
+        .given.withIsOpen(true)
         .given.popupManager(aPopupManager)
         .given.component(testedComponent).when.create();
 

--- a/src/tests/testPopups.spec.tsx
+++ b/src/tests/testPopups.spec.tsx
@@ -1,13 +1,14 @@
 import { TestPopupsDriver } from './TestPopups.driver';
 import { TestPopupsManager } from './testPopupsManager';
 import * as React from 'react';
-import {TestPopup1, TestPopupWithAnimation} from "./testPopups";
+import {TestPopup } from "./testPopups";
 import {PopupManager} from '../popupManager';
 
 describe('Popups', () => {
   let driver: TestPopupsDriver;
   let popupManager: TestPopupsManager;
   const buttonOpen = 'button-open';
+  const generateDataHook = (index = 0) =>  `test-popup-${index}`;
 
   beforeEach(() => {
     driver = new TestPopupsDriver();
@@ -15,11 +16,11 @@ describe('Popups', () => {
   });
 
   it('should open popup using default popup manager', () => {
-    const testedComponent = props => (
+    const testedComponent = (props:{popupManager: PopupManager}) => (
         <div>
           <button
               data-hook="button-open"
-              onClick={() => props.popupManager.open(TestPopup1)}
+              onClick={() => props.popupManager.open(TestPopup, {dataHook: generateDataHook(), content: ''})}
           />
         </div>
     );
@@ -32,15 +33,15 @@ describe('Popups', () => {
     driver.when.inGivenComponent.clickOn(buttonOpen);
 
     expect(driver.get.isPopupOpen()).toBe(true);
-    expect(driver.get.testPopup1().exists()).toBe(true);
+    expect(driver.get.popupDriver(generateDataHook()).get.exists()).toBe(true);
   });
 
   it('should open popup with custom popup manager', () => {
-    const testedComponent = props => (
+    const testedComponent = (props: {popupManager: TestPopupsManager}) => (
       <div>
         <button
           data-hook="button-open"
-          onClick={() => props.popupManager.openTestPopup1()}
+          onClick={() => props.popupManager.openTestPopup(generateDataHook())}
         />
       </div>
     );
@@ -53,7 +54,7 @@ describe('Popups', () => {
     driver.when.inGivenComponent.clickOn(buttonOpen);
 
     expect(driver.get.isPopupOpen()).toBe(true);
-    expect(driver.get.testPopup1().exists()).toBe(true);
+    expect(driver.get.popupDriver(generateDataHook()).get.exists()).toBe(true);
   });
 
   it('should close popup using open\'s return instance', () => {
@@ -67,21 +68,21 @@ describe('Popups', () => {
 
     driver.when.create();
 
-    const testPopup1 = popupManager.openTestPopup1();
+    const testPopup1 = popupManager.openTestPopup(generateDataHook());
     driver.update();
-    expect(driver.get.testPopup1().exists()).toBe(true);
+    expect(driver.get.popupDriver(generateDataHook()).get.exists()).toBe(true);
     testPopup1.close();
     driver.update();
-    expect(driver.get.testPopup1().exists()).toBe(false);
+    expect(driver.get.popupDriver(generateDataHook()).get.exists()).toBe(false);
   });
 
   it('should open popup with custom manager name', () => {
     const customManagerName = 'customName';
-    const testedComponent = props => (
+    const testedComponent = (props: {[customManagerName]: TestPopupsManager}) => (
       <div>
         <button
           data-hook="button-open"
-          onClick={() => props[customManagerName].openTestPopup1()}
+          onClick={() => props[customManagerName].openTestPopup(generateDataHook())}
         />
       </div>
     );
@@ -96,18 +97,18 @@ describe('Popups', () => {
     driver.when.inGivenComponent.clickOn(buttonOpen);
 
     expect(driver.get.isPopupOpen()).toBe(true);
-    expect(driver.get.testPopup1().exists()).toBe(true);
+    expect(driver.get.popupDriver(generateDataHook()).get.exists()).toBe(true);
   });
 
   it('should close popup and call callback', () => {
     const onClose = jest.fn();
     const content = 'popup content';
 
-    const testedComponent = props => (
+    const testedComponent = (props: {popupManager: TestPopupsManager}) => (
       <div>
         <button
           data-hook="button-open"
-          onClick={() => props.popupManager.openTestPopup1(onClose, content)}
+          onClick={() => props.popupManager.openTestPopup(generateDataHook(), onClose, content)}
         />
       </div>
     );
@@ -118,20 +119,19 @@ describe('Popups', () => {
 
     driver.when.inGivenComponent.clickOn(buttonOpen);
 
-    driver.when.testPopup1.closePopup();
-    expect(driver.get.testPopup1().exists()).toBe(false);
+    driver.get.popupDriver(generateDataHook()).when.closePopup();
+    expect(driver.get.popupDriver(generateDataHook()).get.exists()).toBe(false);
     expect(onClose).toHaveBeenCalled();
   });
 
-  it('should close popup with params', () => {
+ it('should close popup with params', () => {
     const onClose = jest.fn();
-    const content = 'popup content';
 
-    const testedComponent = props => (
+    const testedComponent = (props: {popupManager: TestPopupsManager}) => (
         <div>
           <button
               data-hook="button-open"
-              onClick={() => props.popupManager.openTestPopup1(onClose, content)}
+              onClick={() => props.popupManager.openTestPopup(generateDataHook(), onClose)}
           />
         </div>
     );
@@ -142,20 +142,19 @@ describe('Popups', () => {
 
     driver.when.inGivenComponent.clickOn(buttonOpen);
 
-    driver
-        .when.testPopup1.closePopup();
-    expect(driver.get.testPopup1().exists()).toBe(false);
+    driver.get.popupDriver(generateDataHook()).when.closePopup();
+    expect(driver.get.popupDriver(generateDataHook()).get.exists()).toBe(false);
     expect(onClose).toHaveBeenCalledWith('value', true, 1);
   });
 
   it('should pass popup its own props', () => {
     const content = 'popup content';
 
-    const testedComponent = props => (
+    const testedComponent = (props: {popupManager: TestPopupsManager}) => (
       <div>
         <button
           data-hook="button-open"
-          onClick={() => props.popupManager.openTestPopup1(undefined, content)}
+          onClick={() => props.popupManager.openTestPopup(generateDataHook(), undefined, content)}
         />
       </div>
     );
@@ -166,7 +165,7 @@ describe('Popups', () => {
 
     driver.when.inGivenComponent.clickOn(buttonOpen);
 
-    expect(driver.get.testPopup1().content()).toBe(content);
+    expect(driver.get.popupDriver(generateDataHook()).get.content()).toBe(content);
   });
 
   it('should have as many popups open in a time', () => {
@@ -174,11 +173,11 @@ describe('Popups', () => {
       <div>
         <button
           data-hook="button-open"
-          onClick={() => props.popupManager.openTestPopup1()}
+          onClick={() => props.popupManager.openTestPopup(generateDataHook())}
         />
         <button
           data-hook="button-open2"
-          onClick={() => props.popupManager.openTestPopup2()}
+          onClick={() => props.popupManager.openTestPopup(generateDataHook(1))}
         />
       </div>
     );
@@ -189,8 +188,8 @@ describe('Popups', () => {
 
     driver.when.inGivenComponent.clickOn(buttonOpen);
     driver.when.inGivenComponent.clickOn('button-open2');
-    expect(driver.get.testPopup1().exists()).toBe(true);
-    expect(driver.get.testPopup2().exists()).toBe(true);
+    expect(driver.get.popupDriver(generateDataHook()).get.exists()).toBe(true);
+    expect(driver.get.popupDriver(generateDataHook(1)).get.exists()).toBe(true);
   });
 
   it('should allow close all popups', () => {
@@ -198,11 +197,11 @@ describe('Popups', () => {
       <div>
         <button
           data-hook="button-open"
-          onClick={() => props.popupManager.openTestPopup1()}
+          onClick={() => props.popupManager.openTestPopup(generateDataHook())}
         />
         <button
           data-hook="button-open2"
-          onClick={() => props.popupManager.openTestPopup2()}
+          onClick={() => props.popupManager.openTestPopup(generateDataHook(1))}
         />
         <button
           data-hook="button-close-all"
@@ -217,37 +216,10 @@ describe('Popups', () => {
 
     driver.when.inGivenComponent.clickOn(buttonOpen);
     driver.when.inGivenComponent.clickOn('button-open2');
-    expect(driver.get.testPopup1().exists()).toBe(true);
-    expect(driver.get.testPopup2().exists()).toBe(true);
+    expect(driver.get.popupDriver(generateDataHook()).get.exists()).toBe(true);
+    expect(driver.get.popupDriver(generateDataHook(1)).get.exists()).toBe(true);
     driver.when.inGivenComponent.clickOn('button-close-all');
-    expect(driver.get.testPopup1().exists()).toBe(false);
-    expect(driver.get.testPopup2().exists()).toBe(false);
-  });
-
-  fit('should close popup using isOpen - allow animation', () => {
-    const testedComponent = (props:{popupManager: PopupManager})  => (
-      <div>
-        <button
-          data-hook="button-open"
-          onClick={() => props.popupManager.open(TestPopupWithAnimation, {
-            onClose: () => console.log('popup was closed'),
-            timeOutMS: 100,
-            isOpen: true,
-          })}
-        />
-      </div>
-    );
-
-    driver.given.component(testedComponent);
-
-    driver.when.create();
-
-    expect(driver.get.isPopupOpen()).toBe(false);
-    driver.when.inGivenComponent.clickOn(buttonOpen);
-    driver.when.testPopupWithAnimation.closePopup();
-
-    expect(driver.get.testPopupWithAnimation().exists()).toBe(true);
-    jest.advanceTimersByTime(100);
-    expect(driver.get.testPopupWithAnimation().exists()).toBe(false);
+    expect(driver.get.popupDriver(generateDataHook()).get.exists()).toBe(false);
+    expect(driver.get.popupDriver(generateDataHook(1)).get.exists()).toBe(false);
   });
 });

--- a/src/tests/testPopups.spec.tsx
+++ b/src/tests/testPopups.spec.tsx
@@ -1,26 +1,22 @@
 import {TestPopupsDriver} from './TestPopups.driver';
 import {TestPopupsManager} from './testPopupsManager';
 import * as React from 'react';
-import {TestPopup, TestPopupUsesIsOpen} from "./testPopups";
+import {generateDataHook, TestPopupUsesIsOpen} from "./testPopups";
 import {PopupManager} from '../popupManager';
-import {PopupManagerInternal} from '../__internal__/popupManagerInternal';
-import {deprecatedPropWarningMessage, deprecatedWarningMessage} from '../__internal__/common';
 
 describe('Popups', () => {
   let driver: TestPopupsDriver;
   const buttonOpen = 'button-open';
-  const generateDataHook = (index = 0) => `test-popup-${index}`;
-  let popupManager: PopupManager;
+  let popupManager: PopupManager | TestPopupsManager;
 
-  function justBeforeEachTest({withIsOpen, component, popupManager: aPopupManager}: {withIsOpen?: boolean, component?: React.ComponentType<any>, popupManager?: PopupManager | TestPopupsManager} = {}) {
+  function justBeforeEachTest({component, popupManager: aPopupManager, popupManagerName}: {component?: React.ComponentType<any>, popupManager?: PopupManager | TestPopupsManager, popupManagerName?: string} = {}) {
     driver = new TestPopupsDriver();
     console.warn = jest.fn();
     popupManager = aPopupManager ? aPopupManager: new PopupManager();
 
     component && driver.given.component(component);
     driver
-      .given.withIsOpen(withIsOpen)
-      .given.popupManager(popupManager as any).when.create();
+      .given.popupManager(popupManager as any, popupManagerName).when.create();
   }
 
   it('should open popup using default popup manager', () => {
@@ -28,7 +24,7 @@ describe('Popups', () => {
       <div>
         <button
           data-hook="button-open"
-          onClick={() => props.popupManager.open(TestPopup, {dataHook: generateDataHook(), content: ''})}
+          onClick={() => props.popupManager.open(TestPopupUsesIsOpen)}
         />
       </div>
     );
@@ -68,7 +64,7 @@ describe('Popups', () => {
     expect(driver.get.popupDriver(generateDataHook()).get.exists()).toBe(true);
     testPopup1.close();
     driver.update();
-    expect(driver.get.popupDriver(generateDataHook()).get.exists()).toBe(false);
+    expect(driver.get.popupDriver(generateDataHook()).get.isOpen()).toBe(false);
   });
 
   it('should open popup with custom manager name', () => {
@@ -82,11 +78,7 @@ describe('Popups', () => {
       </div>
     );
 
-    driver.given
-      .popupManager(popupManager, customManagerName)
-      .given.component(testedComponent);
-
-    driver.when.create();
+    justBeforeEachTest({popupManager: new TestPopupsManager(), popupManagerName: customManagerName, component: testedComponent});
 
     expect(driver.get.isPopupOpen()).toBe(false);
     driver.when.inGivenComponent.clickOn(buttonOpen);
@@ -112,47 +104,27 @@ describe('Popups', () => {
     driver.when.inGivenComponent.clickOn(buttonOpen);
 
     driver.get.popupDriver(generateDataHook()).when.closePopup();
-    expect(driver.get.popupDriver(generateDataHook()).get.exists()).toBe(false);
+    expect(driver.get.popupDriver(generateDataHook()).get.exists()).toBe(true);
+    expect(driver.get.popupDriver(generateDataHook()).get.isOpen()).toBe(false);
     expect(onClose).toHaveBeenCalled();
   });
 
   it('should close popup with params', () => {
     const onClose = jest.fn();
 
-    const testedComponent = (props: { popupManager: TestPopupsManager }) => (
-      <div>
-        <button
-          data-hook="button-open"
-          onClick={() => props.popupManager.openTestPopup(generateDataHook(), onClose)}
-        />
-      </div>
-    );
-
-    justBeforeEachTest({component: testedComponent, popupManager: new TestPopupsManager()});
-
-    driver.when.inGivenComponent.clickOn(buttonOpen);
-
+    justBeforeEachTest({popupManager: new TestPopupsManager()});
+    (popupManager as TestPopupsManager).openTestPopup(generateDataHook(), onClose);
+    driver.update();
     driver.get.popupDriver(generateDataHook()).when.closePopup();
-    expect(driver.get.popupDriver(generateDataHook()).get.exists()).toBe(false);
+    expect(driver.get.popupDriver(generateDataHook()).get.isOpen()).toBe(false);
     expect(onClose).toHaveBeenCalledWith('value', true, 1);
   });
 
   it('should pass popup its own props', () => {
     const content = 'popup content';
-    const testedComponent = (props: { popupManager: TestPopupsManager }) => (
-      <div>
-        <button
-          data-hook="button-open"
-          onClick={() => props.popupManager.openTestPopup(generateDataHook(), undefined, content)}
-        />
-      </div>
-    );
-
-    justBeforeEachTest({component: testedComponent, popupManager: new TestPopupsManager()});
-
-    driver.when.create();
-
-    driver.when.inGivenComponent.clickOn(buttonOpen);
+    justBeforeEachTest({popupManager: new TestPopupsManager()});
+    (popupManager as TestPopupsManager).openTestPopup(generateDataHook(), undefined, content);
+    driver.update();
 
     expect(driver.get.popupDriver(generateDataHook()).get.content()).toBe(content);
   });
@@ -166,29 +138,8 @@ describe('Popups', () => {
     expect(driver.get.popupDriver(generateDataHook(1)).get.exists()).toBe(true);
   });
 
-  it('should allow close all popups', () => {
-    const testedComponent = props => (
-      <div>
-        <button
-          data-hook="button-close-all"
-          onClick={() => props.popupManager.closeAll()}
-        />
-      </div>
-    );
-    justBeforeEachTest({popupManager: new TestPopupsManager(),component: testedComponent});
-    (popupManager as TestPopupsManager).openTestPopup(generateDataHook());
-    (popupManager as TestPopupsManager).openTestPopup(generateDataHook(1));
-    driver.update();
-    expect(driver.get.popupDriver(generateDataHook()).get.exists()).toBe(true);
-    expect(driver.get.popupDriver(generateDataHook(1)).get.exists()).toBe(true);
-    driver.when.inGivenComponent.clickOn('button-close-all');
-    expect(driver.get.popupDriver(generateDataHook()).get.exists()).toBe(false);
-    expect(driver.get.popupDriver(generateDataHook(1)).get.exists()).toBe(false);
-  });
-
-  describe('with `isOpen` for transitions', () => {
     it('should only hide and not remove popup', () => {
-      justBeforeEachTest({withIsOpen: true});
+      justBeforeEachTest();
       popupManager.open(TestPopupUsesIsOpen, {dataHook: generateDataHook()});
       driver.update();
       expect(driver.get.popupDriver(generateDataHook()).get.exists()).toBe(true);
@@ -198,16 +149,8 @@ describe('Popups', () => {
       expect(driver.get.popupDriver(generateDataHook()).get.isOpen()).toBe(false);
     });
 
-    it('should NOT override isOpen of consumer props', () => {
-      justBeforeEachTest({withIsOpen: false});
-      popupManager.open(TestPopupUsesIsOpen, {dataHook: generateDataHook(), isOpen: false});
-      driver.update();
-      expect(driver.get.popupDriver(generateDataHook()).get.exists()).toBe(true);
-      expect(driver.get.popupDriver(generateDataHook()).get.isOpen()).toBe(false);
-    });
-
     it('should allow threshold of 10 closed popups in DOM only. First Closed First Removed', () => {
-      justBeforeEachTest({withIsOpen: true});
+      justBeforeEachTest();
       const popupThreshold = 10;
       for (let popupDataHookIndex = 0; popupDataHookIndex <= popupThreshold; popupDataHookIndex++) {
         popupManager.open(TestPopupUsesIsOpen, {dataHook: generateDataHook(popupDataHookIndex)});
@@ -223,8 +166,8 @@ describe('Popups', () => {
       expect(driver.get.popupDriver(generateDataHook(1)).get.isOpen()).toBe(false);
     });
 
-    it('should close all popups. threshold 10. First Closed First Removed', () => {
-      justBeforeEachTest({withIsOpen: true});
+    it('should CLOSE ALL popups. threshold 10. First Closed First Removed', () => {
+      justBeforeEachTest();
       const popupThreshold = 10;
 
       for (let popupDataHookIndex  = 0; popupDataHookIndex  <= popupThreshold; popupDataHookIndex ++) {
@@ -234,54 +177,30 @@ describe('Popups', () => {
       popupManager.closeAll();
       driver.update();
       expect(driver.get.popupDriver(generateDataHook(0)).get.exists()).toBe(false);
-      expect(driver.get.popupDriver(generateDataHook(1)).get.exists()).toBe(true);
-      expect(driver.get.popupDriver(generateDataHook(1)).get.isOpen()).toBe(false);
+      for (let popupDataHookIndex  = 1; popupDataHookIndex  <= popupThreshold; popupDataHookIndex ++) {
+        expect(driver.get.popupDriver(generateDataHook(popupDataHookIndex)).get.exists()).toBe(true);
+        expect(driver.get.popupDriver(generateDataHook(popupDataHookIndex)).get.isOpen()).toBe(false);
+      }
     });
-  });
 
   describe('deprecations', () => {
-    it('should console.war on using deprecated message', () => {
-      justBeforeEachTest({withIsOpen: true});
-      // all should be strikethrough
-      popupManager.close('guid');
-      popupManager.onPopupsChangeEvents;
-      popupManager.openPopups;
-      popupManager.subscribeOnPopupsChange(() => ({}));
-
-      expect(console.warn).toBeCalledWith(deprecatedWarningMessage('close'));
-      expect(console.warn).toBeCalledWith(deprecatedWarningMessage('onPopupsChangeEvents'));
-      expect(console.warn).toBeCalledWith(deprecatedWarningMessage('openPopups'));
-      expect(console.warn).toBeCalledWith(deprecatedWarningMessage('subscribeOnPopupsChange'));
-    });
-
-    it('should NOT console.war on using deprecated message when it is PopupManager for Internal usage', () => {
-      justBeforeEachTest({withIsOpen: true});
-      const popupManagerInternal: PopupManagerInternal = popupManager as any;
-
-      // all shouldn't be strikethrough
-      popupManagerInternal._close('guid');
-      popupManagerInternal._onPopupsChangeEvents;
-      popupManagerInternal.popups;
-      popupManagerInternal._subscribeOnPopupsChange(() => ({}));
-
-      expect(console.warn).not.toBeCalled();
-    });
-
-
-    it('should console.warn if user sends `isOpen` to open props when `withIsOpen` is false', () => {
-      justBeforeEachTest({withIsOpen: false});
-      popupManager.open(TestPopupUsesIsOpen, {dataHook: generateDataHook(), isOpen: true});
-
-      expect(console.warn).toBeCalledWith(deprecatedPropWarningMessage('isOpen'));
-    });
-
-    it('should throw error if user sends `isOpen` to open props when `withIsOpen` as false', done => {
-      justBeforeEachTest({withIsOpen: true});
-
+    it('should throw error if user sends `isOpen` to open popupProps', done => {
+      justBeforeEachTest();
       try {
-        popupManager.open(TestPopupUsesIsOpen, {dataHook: generateDataHook(), isOpen: true})
+        popupManager.open(TestPopupUsesIsOpen, {dataHook: generateDataHook(), isOpen: true} as any)
       } catch (e) {
-        expect(e.message).toBe(`'isOpen' prop is deprecated and not allowed. if you wish to use it, remove 'withIsOpen' from 'PopupProvider'`);
+        expect(e.message).toBe(`it is not allowed to send 'isOpen' in popupProps to 'popupManager.open(component, popupProps)'`);
+        done();
+      }
+    });
+
+    it('should throw error if user sends `isOpen` to open popupProps also if `False`', (done) => {
+      justBeforeEachTest();
+      try {
+        (popupManager as PopupManager).open(TestPopupUsesIsOpen, {dataHook: generateDataHook(), isOpen: false} as any);
+      }
+      catch (e) {
+        expect(e.message).toBe(`it is not allowed to send 'isOpen' in popupProps to 'popupManager.open(component, popupProps)'`);
         done();
       }
     });

--- a/src/tests/testPopups.tsx
+++ b/src/tests/testPopups.tsx
@@ -1,23 +1,56 @@
 import * as React from 'react';
-import { PopupProps } from '../popupsDef';
+import {PopupProps} from '../popupsDef';
 
 interface TestPopup1Props extends PopupProps {
-    content: string;
+  content: string;
 }
 
 interface TestPopup2Props extends PopupProps {
-    [s: string]: any;
+  [s: string]: any;
 }
+
+interface TestPopup1WithAnimationProps extends PopupProps {
+  timeOutMS: number;
+}
+
+class PopupWithAnimation extends React.Component<{ isOpen: boolean, timeOutMS: number }, { isOpen: boolean }> {
+  state = {isOpen: false};
+
+  componentDidMount(): void {
+    this.setState({isOpen: this.props.isOpen});
+  }
+
+  componentWillReceiveProps(nextProps: Readonly<{ isOpen: boolean, timeOutMS: number }>, nextContext: any): void {
+    if (nextProps.isOpen) {
+      setTimeout(() => this.setState({isOpen: nextProps.isOpen}), nextProps.timeOutMS)
+    }
+  }
+
+  render() {
+    return (
+      this.state.isOpen && <div data-hook="test-popup-with-animation">
+        {this.props.children}
+        </div>
+    );
+  }
+}
+
+
+export const TestPopupWithAnimation = (props: TestPopup1WithAnimationProps) => (
+  <PopupWithAnimation isOpen={props.isOpen} timeOutMS={props.timeOutMS}>
+    <button data-hook="close-button" onClick={() => props.onClose()}/>
+  </PopupWithAnimation>
+);
 
 export const TestPopup1 = (props: TestPopup2Props) => (
   <div data-hook="test-hook">
     <span data-hook="popup-content">{props.content}</span>
-    <button data-hook="close-button" onClick={() => props.onClose('value', true, 1)} />
+    <button data-hook="close-button" onClick={() => props.onClose('value', true, 1)}/>
   </div>
 );
 
 export const TestPopup2 = (props: TestPopup1Props) => (
   <div data-hook="test-hook2">
-    <button data-hook="close-button" onClick={() => props.onClose} />
+    <button data-hook="close-button" onClick={() => props.onClose}/>
   </div>
 );

--- a/src/tests/testPopups.tsx
+++ b/src/tests/testPopups.tsx
@@ -2,8 +2,8 @@ import * as React from 'react';
 import {PopupProps} from '../popupsDef';
 
 interface TestPopupProps extends PopupProps {
-  content: string;
-  dataHook: string;
+  content?: string;
+  dataHook?: string;
 }
 export const TestPopup = (props: TestPopupProps) => (
   <div data-hook={props.dataHook}>

--- a/src/tests/testPopups.tsx
+++ b/src/tests/testPopups.tsx
@@ -14,7 +14,7 @@ export const TestPopup = (props: TestPopupProps) => (
 
 
 export const TestPopupUsesIsOpen = (props: TestPopupProps) => (
-  <div is-open={props.isOpen} data-hook={props.dataHook}>
+  <div data-is-open={props.isOpen} data-hook={props.dataHook}>
     <span data-hook="popup-content">{props.content}</span>
     <button data-hook="close-button" onClick={() => props.onClose('value', true, 1)}/>
   </div>

--- a/src/tests/testPopups.tsx
+++ b/src/tests/testPopups.tsx
@@ -5,16 +5,10 @@ interface TestPopupProps extends PopupProps {
   content?: string;
   dataHook?: string;
 }
-export const TestPopup = (props: TestPopupProps) => (
-  <div data-hook={props.dataHook}>
-    <span data-hook="popup-content">{props.content}</span>
-    <button data-hook="close-button" onClick={() => props.onClose('value', true, 1)}/>
-  </div>
-);
 
-
+export const generateDataHook = (index = 0) => `test-popup-${index}`;
 export const TestPopupUsesIsOpen = (props: TestPopupProps) => (
-  <div data-is-open={props.isOpen} data-hook={props.dataHook}>
+  <div data-is-open={props.isOpen} data-hook={props.dataHook || generateDataHook()}>
     <span data-hook="popup-content">{props.content}</span>
     <button data-hook="close-button" onClick={() => props.onClose('value', true, 1)}/>
   </div>

--- a/src/tests/testPopups.tsx
+++ b/src/tests/testPopups.tsx
@@ -1,56 +1,21 @@
 import * as React from 'react';
 import {PopupProps} from '../popupsDef';
 
-interface TestPopup1Props extends PopupProps {
+interface TestPopupProps extends PopupProps {
   content: string;
+  dataHook: string;
 }
-
-interface TestPopup2Props extends PopupProps {
-  [s: string]: any;
-}
-
-interface TestPopup1WithAnimationProps extends PopupProps {
-  timeOutMS: number;
-}
-
-class PopupWithAnimation extends React.Component<{ isOpen: boolean, timeOutMS: number }, { isOpen: boolean }> {
-  state = {isOpen: false};
-
-  componentDidMount(): void {
-    this.setState({isOpen: this.props.isOpen});
-  }
-
-  componentWillReceiveProps(nextProps: Readonly<{ isOpen: boolean, timeOutMS: number }>, nextContext: any): void {
-    if (nextProps.isOpen) {
-      setTimeout(() => this.setState({isOpen: nextProps.isOpen}), nextProps.timeOutMS)
-    }
-  }
-
-  render() {
-    return (
-      this.state.isOpen && <div data-hook="test-popup-with-animation">
-        {this.props.children}
-        </div>
-    );
-  }
-}
-
-
-export const TestPopupWithAnimation = (props: TestPopup1WithAnimationProps) => (
-  <PopupWithAnimation isOpen={props.isOpen} timeOutMS={props.timeOutMS}>
-    <button data-hook="close-button" onClick={() => props.onClose()}/>
-  </PopupWithAnimation>
-);
-
-export const TestPopup1 = (props: TestPopup2Props) => (
-  <div data-hook="test-hook">
+export const TestPopup = (props: TestPopupProps) => (
+  <div data-hook={props.dataHook}>
     <span data-hook="popup-content">{props.content}</span>
     <button data-hook="close-button" onClick={() => props.onClose('value', true, 1)}/>
   </div>
 );
 
-export const TestPopup2 = (props: TestPopup1Props) => (
-  <div data-hook="test-hook2">
-    <button data-hook="close-button" onClick={() => props.onClose}/>
+
+export const TestPopupUsesIsOpen = (props: TestPopupProps) => (
+  <div is-open={props.isOpen} data-hook={props.dataHook}>
+    <span data-hook="popup-content">{props.content}</span>
+    <button data-hook="close-button" onClick={() => props.onClose('value', true, 1)}/>
   </div>
 );

--- a/src/tests/testPopupsManager.ts
+++ b/src/tests/testPopupsManager.ts
@@ -1,5 +1,6 @@
-import {popupInstance, PopupManager} from '../popupManager';
+import {PopupManager} from '../popupManager';
 import { TestPopup  } from './testPopups';
+import {popupInstance} from '../popupsDef';
 
 export class TestPopupsManager extends PopupManager {
   public openTestPopup(dataHook: string, onClose?: () => void, content?: string): popupInstance {

--- a/src/tests/testPopupsManager.ts
+++ b/src/tests/testPopupsManager.ts
@@ -1,12 +1,8 @@
 import {popupInstance, PopupManager} from '../popupManager';
-import { TestPopup1, TestPopup2 } from './testPopups';
+import { TestPopup  } from './testPopups';
 
 export class TestPopupsManager extends PopupManager {
-  public openTestPopup1(onClose?: () => void, content?: string): popupInstance {
-    return this.open(TestPopup1, { onClose, content });
-  }
-
-  public openTestPopup2(): popupInstance {
-    return this.open(TestPopup2);
+  public openTestPopup(dataHook: string, onClose?: () => void, content?: string): popupInstance {
+    return this.open(TestPopup, { onClose, content, dataHook });
   }
 }

--- a/src/tests/testPopupsManager.ts
+++ b/src/tests/testPopupsManager.ts
@@ -1,9 +1,9 @@
 import {PopupManager} from '../popupManager';
-import { TestPopup  } from './testPopups';
+import { TestPopupUsesIsOpen  } from './testPopups';
 import {popupInstance} from '../popupsDef';
 
 export class TestPopupsManager extends PopupManager {
   public openTestPopup(dataHook: string, onClose?: () => void, content?: string): popupInstance {
-    return this.open(TestPopup, { onClose, content, dataHook });
+    return this.open(TestPopupUsesIsOpen, { onClose, content, dataHook });
   }
 }

--- a/tslint.json
+++ b/tslint.json
@@ -1,3 +1,6 @@
 {
-  "extends": "tslint-config-yoshi"
+  "extends": "tslint-config-yoshi",
+  "rules": {
+    "prefer-method-signature": false
+  }
 }


### PR DESCRIPTION
changed `PopupManager` `close` approach:
instead of *removing* popup from `DOM`, it changes it's `isOpen` `prop`.
this will allow in-library implemented transitions on `Open` and on `Close`.
*for example: react-popup will fade-out instead of just disappear. *